### PR TITLE
Ignore default value for cpu.architecture when the root account is not being used

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,12 @@
-## 0.4.0
+## 0.4.0 (UNRELEASED)
 
 BUG FIXES:
 
 * library/virtual_environment_nodes: Fix node IP address format
+
+WORKAROUNDS:
+
+* resource/virtual_environment_vm: Ignore default value for `cpu.architecture` when the root account is not being used
 
 ## 0.3.0
 

--- a/proxmox/virtual_environment_authentication.go
+++ b/proxmox/virtual_environment_authentication.go
@@ -13,6 +13,11 @@ import (
 	"net/url"
 )
 
+const (
+	// DefaultRootAccount contains the default username and realm for the root account.
+	DefaultRootAccount = "root@pam"
+)
+
 // Authenticate authenticates against the specified endpoint.
 func (c *VirtualEnvironmentClient) Authenticate(reset bool) error {
 	if c.authenticationData != nil && !reset {


### PR DESCRIPTION
<!--- Please keep this note for the community --->
### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request
<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates #10 

Release note for [CHANGELOG](https://github.com/danitso/terraform-provider-proxmox/blob/master/CHANGELOG.md):
<!-- If change is not user facing, just write "NONE" in the release-note block below. -->

```release-note
WORKAROUNDS:

* resource/virtual_environment_vm: Ignore default value for `cpu.architecture` when the root account is not being used
```
