### PR TITLE
Parameter added to define if a Full or Linked Clone should be created

### DIFF
--- a/proxmoxtf/resource_virtual_environment_vm.go
+++ b/proxmoxtf/resource_virtual_environment_vm.go
@@ -30,6 +30,7 @@ const (
 	dvResourceVirtualEnvironmentVMCDROMFileID                       = ""
 	dvResourceVirtualEnvironmentVMCloneDatastoreID                  = ""
 	dvResourceVirtualEnvironmentVMCloneNodeName                     = ""
+	dvResourceVirtualEnvironmentVMCloneFull                         = true
 	dvResourceVirtualEnvironmentVMCPUArchitecture                   = "x86_64"
 	dvResourceVirtualEnvironmentVMCPUCores                          = 1
 	dvResourceVirtualEnvironmentVMCPUHotplugged                     = 0
@@ -98,6 +99,7 @@ const (
 	mkResourceVirtualEnvironmentVMCloneDatastoreID                  = "datastore_id"
 	mkResourceVirtualEnvironmentVMCloneNodeName                     = "node_name"
 	mkResourceVirtualEnvironmentVMCloneVMID                         = "vm_id"
+	mkResourceVirtualEnvironmentVMCloneFull                         = "full"
 	mkResourceVirtualEnvironmentVMCPU                               = "cpu"
 	mkResourceVirtualEnvironmentVMCPUArchitecture                   = "architecture"
 	mkResourceVirtualEnvironmentVMCPUCores                          = "cores"
@@ -325,6 +327,13 @@ func resourceVirtualEnvironmentVM() *schema.Resource {
 							Required:     true,
 							ForceNew:     true,
 							ValidateFunc: getVMIDValidator(),
+						},
+						mkResourceVirtualEnvironmentVMCloneFull: {
+							Type:        schema.TypeBool,
+							Description: "The Clone Type, create a Full Clone (true) or a linked Clone (false)",
+							Optional:    true,
+							ForceNew:    true,
+							Default:     dvResourceVirtualEnvironmentVMCloneFull,
 						},
 					},
 				},
@@ -973,6 +982,7 @@ func resourceVirtualEnvironmentVMCreateClone(d *schema.ResourceData, m interface
 	cloneDatastoreID := cloneBlock[mkResourceVirtualEnvironmentVMCloneDatastoreID].(string)
 	cloneNodeName := cloneBlock[mkResourceVirtualEnvironmentVMCloneNodeName].(string)
 	cloneVMID := cloneBlock[mkResourceVirtualEnvironmentVMCloneVMID].(int)
+	cloneFull := cloneBlock[mkResourceVirtualEnvironmentVMCloneFull].(bool)
 
 	description := d.Get(mkResourceVirtualEnvironmentVMDescription).(string)
 	name := d.Get(mkResourceVirtualEnvironmentVMName).(string)
@@ -990,7 +1000,7 @@ func resourceVirtualEnvironmentVMCreateClone(d *schema.ResourceData, m interface
 		vmID = *vmIDNew
 	}
 
-	fullCopy := proxmox.CustomBool(true)
+	fullCopy := proxmox.CustomBool(cloneFull)
 
 	cloneBody := &proxmox.VirtualEnvironmentVMCloneRequestBody{
 		FullCopy: &fullCopy,


### PR DESCRIPTION
<!--- Please keep this note for the community --->
### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request
<!--- Thank you for keeping this note for the community --->

Release note for [CHANGELOG](https://github.com/danitso/terraform-provider-proxmox/blob/master/CHANGELOG.md):
<!-- If change is not user facing, just write "NONE" in the release-note block below. -->

```release-note
The optional Parameter "full" can be used to create a linked clone instead a full clone by set to false (default: true).
```

Output from acceptance testing:

```sh
$ make test

go test -v ./...
?       github.com/danitso/terraform-provider-proxmox   [no test files]
?       github.com/danitso/terraform-provider-proxmox/proxmox   [no test files]
=== RUN   TestDataSourceVirtualEnvironmentDatastoresInstantiation
--- PASS: TestDataSourceVirtualEnvironmentDatastoresInstantiation (0.00s)
=== RUN   TestDataSourceVirtualEnvironmentDatastoresSchema
--- PASS: TestDataSourceVirtualEnvironmentDatastoresSchema (0.00s)
=== RUN   TestDataSourceVirtualEnvironmentDNSInstantiation
--- PASS: TestDataSourceVirtualEnvironmentDNSInstantiation (0.00s)
=== RUN   TestDataSourceVirtualEnvironmentDNSSchema
--- PASS: TestDataSourceVirtualEnvironmentDNSSchema (0.00s)
=== RUN   TestDataSourceVirtualEnvironmentGroupInstantiation
--- PASS: TestDataSourceVirtualEnvironmentGroupInstantiation (0.00s)
=== RUN   TestDataSourceVirtualEnvironmentGroupSchema
--- PASS: TestDataSourceVirtualEnvironmentGroupSchema (0.00s)
=== RUN   TestDataSourceVirtualEnvironmentGroupsInstantiation
--- PASS: TestDataSourceVirtualEnvironmentGroupsInstantiation (0.00s)
=== RUN   TestDataSourceVirtualEnvironmentGroupsSchema
--- PASS: TestDataSourceVirtualEnvironmentGroupsSchema (0.00s)
=== RUN   TestDataSourceVirtualEnvironmentHostsInstantiation
--- PASS: TestDataSourceVirtualEnvironmentHostsInstantiation (0.00s)
=== RUN   TestDataSourceVirtualEnvironmentHostsSchema
--- PASS: TestDataSourceVirtualEnvironmentHostsSchema (0.00s)
=== RUN   TestDataSourceVirtualEnvironmentNodesInstantiation
--- PASS: TestDataSourceVirtualEnvironmentNodesInstantiation (0.00s)
=== RUN   TestDataSourceVirtualEnvironmentNodesSchema
--- PASS: TestDataSourceVirtualEnvironmentNodesSchema (0.00s)
=== RUN   TestDataSourceVirtualEnvironmentPoolInstantiation
--- PASS: TestDataSourceVirtualEnvironmentPoolInstantiation (0.00s)
=== RUN   TestDataSourceVirtualEnvironmentPoolSchema
--- PASS: TestDataSourceVirtualEnvironmentPoolSchema (0.00s)
=== RUN   TestDataSourceVirtualEnvironmentPoolsInstantiation
--- PASS: TestDataSourceVirtualEnvironmentPoolsInstantiation (0.00s)
=== RUN   TestDataSourceVirtualEnvironmentPoolsSchema
--- PASS: TestDataSourceVirtualEnvironmentPoolsSchema (0.00s)
=== RUN   TestDataSourceVirtualEnvironmentRoleInstantiation
--- PASS: TestDataSourceVirtualEnvironmentRoleInstantiation (0.00s)
=== RUN   TestDataSourceVirtualEnvironmentRoleSchema
--- PASS: TestDataSourceVirtualEnvironmentRoleSchema (0.00s)
=== RUN   TestDataSourceVirtualEnvironmentRolesInstantiation
--- PASS: TestDataSourceVirtualEnvironmentRolesInstantiation (0.00s)
=== RUN   TestDataSourceVirtualEnvironmentRolesSchema
--- PASS: TestDataSourceVirtualEnvironmentRolesSchema (0.00s)
=== RUN   TestDataSourceVirtualEnvironmentUserInstantiation
--- PASS: TestDataSourceVirtualEnvironmentUserInstantiation (0.00s)
=== RUN   TestDataSourceVirtualEnvironmentUserSchema
--- PASS: TestDataSourceVirtualEnvironmentUserSchema (0.00s)
=== RUN   TestDataSourceVirtualEnvironmentUsersInstantiation
--- PASS: TestDataSourceVirtualEnvironmentUsersInstantiation (0.00s)
=== RUN   TestDataSourceVirtualEnvironmentUsersSchema
--- PASS: TestDataSourceVirtualEnvironmentUsersSchema (0.00s)
=== RUN   TestDataSourceVirtualEnvironmentVersionInstantiation
--- PASS: TestDataSourceVirtualEnvironmentVersionInstantiation (0.00s)
=== RUN   TestDataSourceVirtualEnvironmentVersionSchema
--- PASS: TestDataSourceVirtualEnvironmentVersionSchema (0.00s)
=== RUN   TestProviderInstantiation
--- PASS: TestProviderInstantiation (0.00s)
=== RUN   TestProviderSchema
--- PASS: TestProviderSchema (0.00s)
=== RUN   TestResourceVirtualEnvironmentCertificateInstantiation
--- PASS: TestResourceVirtualEnvironmentCertificateInstantiation (0.00s)
=== RUN   TestResourceVirtualEnvironmentCertificateSchema
--- PASS: TestResourceVirtualEnvironmentCertificateSchema (0.00s)
=== RUN   TestResourceVirtualEnvironmentContainerInstantiation
--- PASS: TestResourceVirtualEnvironmentContainerInstantiation (0.00s)
=== RUN   TestResourceVirtualEnvironmentContainerSchema
--- PASS: TestResourceVirtualEnvironmentContainerSchema (0.00s)
=== RUN   TestResourceVirtualEnvironmentDNSInstantiation
--- PASS: TestResourceVirtualEnvironmentDNSInstantiation (0.00s)
=== RUN   TestResourceVirtualEnvironmentDNSSchema
--- PASS: TestResourceVirtualEnvironmentDNSSchema (0.00s)
=== RUN   TestResourceVirtualEnvironmentFileInstantiation
--- PASS: TestResourceVirtualEnvironmentFileInstantiation (0.00s)
=== RUN   TestResourceVirtualEnvironmentFileSchema
--- PASS: TestResourceVirtualEnvironmentFileSchema (0.00s)
=== RUN   TestResourceVirtualEnvironmentGroupInstantiation
--- PASS: TestResourceVirtualEnvironmentGroupInstantiation (0.00s)
=== RUN   TestResourceVirtualEnvironmentGroupSchema
--- PASS: TestResourceVirtualEnvironmentGroupSchema (0.00s)
=== RUN   TestResourceVirtualEnvironmentHostsInstantiation
--- PASS: TestResourceVirtualEnvironmentHostsInstantiation (0.00s)
=== RUN   TestResourceVirtualEnvironmentHostsSchema
--- PASS: TestResourceVirtualEnvironmentHostsSchema (0.00s)
=== RUN   TestResourceVirtualEnvironmentPoolInstantiation
--- PASS: TestResourceVirtualEnvironmentPoolInstantiation (0.00s)
=== RUN   TestResourceVirtualEnvironmentPoolSchema
--- PASS: TestResourceVirtualEnvironmentPoolSchema (0.00s)
=== RUN   TestResourceVirtualEnvironmentRoleInstantiation
--- PASS: TestResourceVirtualEnvironmentRoleInstantiation (0.00s)
=== RUN   TestResourceVirtualEnvironmentRoleSchema
--- PASS: TestResourceVirtualEnvironmentRoleSchema (0.00s)
=== RUN   TestResourceVirtualEnvironmentUserInstantiation
--- PASS: TestResourceVirtualEnvironmentUserInstantiation (0.00s)
=== RUN   TestResourceVirtualEnvironmentUserSchema
--- PASS: TestResourceVirtualEnvironmentUserSchema (0.00s)
=== RUN   TestResourceVirtualEnvironmentVMInstantiation
--- PASS: TestResourceVirtualEnvironmentVMInstantiation (0.00s)
=== RUN   TestResourceVirtualEnvironmentVMSchema
--- PASS: TestResourceVirtualEnvironmentVMSchema (0.00s)
PASS
ok      github.com/danitso/terraform-provider-proxmox/proxmoxtf 0.010s
...
```
