### PR TITLE
Add support for importing VM resources

### DIFF
--- a/proxmoxtf/resource_virtual_environment_vm.go
+++ b/proxmoxtf/resource_virtual_environment_vm.go
@@ -947,6 +947,17 @@ func resourceVirtualEnvironmentVM() *schema.Resource {
 		Read:   resourceVirtualEnvironmentVMRead,
 		Update: resourceVirtualEnvironmentVMUpdate,
 		Delete: resourceVirtualEnvironmentVMDelete,
+		Importer: &schema.ResourceImporter{
+			State: func(d *schema.ResourceData, m interface{}) ([]*schema.ResourceData, error) {
+				parts := strings.Split(d.Id(), "/")
+				if len(parts) != 3 {
+					return nil, fmt.Errorf("Malformed import ID: use <host>/quemu/<id>")
+				}
+				d.SetId(parts[2])
+				d.Set(mkResourceVirtualEnvironmentVMNodeName, parts[0])
+				return []*schema.ResourceData{d}, nil
+			},
+		},
 	}
 }
 


### PR DESCRIPTION
This draft PR allows users to import VM resources with something like this:

```
$ terraform import proxmox_virtual_environment_vm.myvm host123/qemu/100
```

<!--- Please keep this note for the community --->
### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request
<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #25 

Release note for [CHANGELOG](https://github.com/danitso/terraform-provider-proxmox/blob/master/CHANGELOG.md):
<!-- If change is not user facing, just write "NONE" in the release-note block below. -->

```release-note
Add support for importing VM resources
```
