### PR TITLE
Fix index out of range error on read

### DIFF
--- a/proxmoxtf/resource_virtual_environment_vm.go
+++ b/proxmoxtf/resource_virtual_environment_vm.go
@@ -2205,14 +2205,16 @@ func resourceVirtualEnvironmentVMReadCustom(d *schema.ResourceData, m interface{
 			cdromBlock[mkResourceVirtualEnvironmentVMCDROMEnabled] = vmConfig.IDEDevice3.Enabled
 			cdromBlock[mkResourceVirtualEnvironmentVMCDROMFileID] = vmConfig.IDEDevice3.FileVolume
 
-			isCurrentCDROMFileId := currentCDROM[0].(map[string]interface{})
+			if len(currentCDROM) > 0 {
+				isCurrentCDROMFileId := currentCDROM[0].(map[string]interface{})
 
-			if isCurrentCDROMFileId[mkResourceVirtualEnvironmentVMCDROMFileID] == "" {
-				cdromBlock[mkResourceVirtualEnvironmentVMCDROMFileID] = ""
-			}
+				if isCurrentCDROMFileId[mkResourceVirtualEnvironmentVMCDROMFileID] == "" {
+					cdromBlock[mkResourceVirtualEnvironmentVMCDROMFileID] = ""
+				}
 
-			if isCurrentCDROMFileId[mkResourceVirtualEnvironmentVMCDROMEnabled] == false {
-				cdromBlock[mkResourceVirtualEnvironmentVMCDROMEnabled] = false
+				if isCurrentCDROMFileId[mkResourceVirtualEnvironmentVMCDROMEnabled] == false {
+					cdromBlock[mkResourceVirtualEnvironmentVMCDROMEnabled] = false
+				}
 			}
 
 			cdrom[0] = cdromBlock


### PR DESCRIPTION
<!--- Please keep this note for the community --->
### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request
<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
relates to #46

Release note for [CHANGELOG](https://github.com/danitso/terraform-provider-proxmox/blob/master/CHANGELOG.md):
<!-- If change is not user facing, just write "NONE" in the release-note block below. -->

```release-note
BUG FIX: fixes index out of range errors when using both cloud-init and cdrom
```

this is addressing a constraint guarding issue where `if len(clone) == 0 || len(currentCDROM) > 0 {` allows `currentCDROM` to be of length zero but expects at least 1 element when accessing in `isCurrentCDROMFileId := currentCDROM[0].(map[string]interface{})`. I am just wrapping the statements that require a non-zero length in a secondary constraint.