### PR TITLE
Adding citype support for custom cloud config

### DIFF
--- a/proxmoxtf/resource_virtual_environment_vm.go
+++ b/proxmoxtf/resource_virtual_environment_vm.go
@@ -55,6 +55,7 @@ const (
 	dvResourceVirtualEnvironmentVMInitializationIPConfigIPv6Gateway = ""
 	dvResourceVirtualEnvironmentVMInitializationUserAccountPassword = ""
 	dvResourceVirtualEnvironmentVMInitializationUserDataFileID      = ""
+	dvResourceVirtualEnvironmentVMInitializationType                = ""
 	dvResourceVirtualEnvironmentVMKeyboardLayout                    = "en-us"
 	dvResourceVirtualEnvironmentVMMemoryDedicated                   = 512
 	dvResourceVirtualEnvironmentVMMemoryFloating                    = 0
@@ -131,6 +132,7 @@ const (
 	mkResourceVirtualEnvironmentVMInitializationIPConfigIPv6        = "ipv6"
 	mkResourceVirtualEnvironmentVMInitializationIPConfigIPv6Address = "address"
 	mkResourceVirtualEnvironmentVMInitializationIPConfigIPv6Gateway = "gateway"
+	mkResourceVirtualEnvironmentVMInitializationType                = "type"
 	mkResourceVirtualEnvironmentVMInitializationUserAccount         = "user_account"
 	mkResourceVirtualEnvironmentVMInitializationUserAccountKeys     = "keys"
 	mkResourceVirtualEnvironmentVMInitializationUserAccountPassword = "password"
@@ -673,6 +675,14 @@ func resourceVirtualEnvironmentVM() *schema.Resource {
 							ForceNew:     true,
 							Default:      dvResourceVirtualEnvironmentVMInitializationUserDataFileID,
 							ValidateFunc: getFileIDValidator(),
+						},
+						mkResourceVirtualEnvironmentVMInitializationType: {
+							Type:         schema.TypeString,
+							Description:  "The cloud-init configuration format",
+							Optional:     true,
+							ForceNew:     true,
+							Default:      dvResourceVirtualEnvironmentVMInitializationType,
+							ValidateFunc: getCloudInitTypeValidator(),
 						},
 					},
 				},
@@ -1854,6 +1864,12 @@ func resourceVirtualEnvironmentVMGetCloudInitConfig(d *schema.ResourceData, m in
 				UserVolume: &initializationUserDataFileID,
 			}
 		}
+
+		initializationType := initializationBlock[mkResourceVirtualEnvironmentVMInitializationType].(string)
+
+		if initializationType != "" {
+			initializationConfig.Type = &initializationType
+		}
 	}
 
 	return initializationConfig, nil
@@ -2553,6 +2569,12 @@ func resourceVirtualEnvironmentVMReadCustom(d *schema.ResourceData, m interface{
 		}
 	} else {
 		initialization[mkResourceVirtualEnvironmentVMInitializationUserDataFileID] = ""
+	}
+
+	if vmConfig.CloudInitType != nil {
+		initialization[mkResourceVirtualEnvironmentVMInitializationType] = *vmConfig.CloudInitType
+	} else if len(initialization) > 0 {
+		initialization[mkResourceVirtualEnvironmentVMInitializationType] = ""
 	}
 
 	currentInitialization := d.Get(mkResourceVirtualEnvironmentVMInitialization).([]interface{})

--- a/proxmoxtf/utils.go
+++ b/proxmoxtf/utils.go
@@ -370,6 +370,13 @@ func getVMIDValidator() schema.SchemaValidateFunc {
 	}
 }
 
+func getCloudInitTypeValidator() schema.SchemaValidateFunc {
+	return validation.StringInSlice([]string{
+		"configdrive2",
+		"nocloud",
+	}, false)
+}
+
 func testComputedAttributes(t *testing.T, s *schema.Resource, keys []string) {
 	for _, v := range keys {
 		if s.Schema[v] == nil {


### PR DESCRIPTION
<!--- Please keep this note for the community --->
### Community Note

This is useful for deploying [RancherOS](https://rancher.com/docs/os/v1.x/en/) which requires `configdrive2` for `citype`

this includes a similar fix to #57 for `initialization` state diffs

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request
<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->

Release note for [CHANGELOG](https://github.com/danitso/terraform-provider-proxmox/blob/master/CHANGELOG.md):
<!-- If change is not user facing, just write "NONE" in the release-note block below. -->

```release-note
adding new type field to the initialization block to specify the citype
```

see [config docs](https://pve.proxmox.com/wiki/Manual:_qm.conf#_options) for more details

Example:

```tf
resource "proxmox_virtual_environment_vm" "test_vm" {
  # ...

  initialization {
    user_data_file_id = proxmox_virtual_environment_file.test_vm_cloud_config.id
    type = "configdrive2"
  }
}

resource "proxmox_virtual_environment_file" "rancheros_template_cloud_config" {
  # ...
}
```
