### PR TITLE
add `alias` cluster resource

### DIFF
--- a/docs/data_sources/virtual_environment/data_source_virtual_environment_alias.md
+++ b/docs/data_sources/virtual_environment/data_source_virtual_environment_alias.md
@@ -1,0 +1,28 @@
+---
+layout: page
+title: Alias
+permalink: /data-sources/virtual-environment/alias
+nav_order: 1
+parent: Virtual Environment Data Sources
+---
+
+# Data Source: Alias
+
+Retrieves information about a specific alias.
+
+## Example Usage
+
+```
+data "proxmox_virtual_environment_cluster_alias" "local_network" {
+  name    = "local_network"
+}
+```
+
+## Arguments Reference
+
+* `name` - (Required) Alias name.
+
+## Attributes Reference
+
+* `cidr` - (Required) Network/IP specification in CIDR format.
+* `comment` - (Optional) Alias comment.

--- a/docs/data_sources/virtual_environment/data_source_virtual_environment_aliases.md
+++ b/docs/data_sources/virtual_environment/data_source_virtual_environment_aliases.md
@@ -1,0 +1,26 @@
+---
+layout: page
+title: Aliases
+permalink: /data-sources/virtual-environment/aliases
+nav_order: 1
+parent: Virtual Environment Data Sources
+parent: Data Sources
+---
+
+# Data Source: Aliases
+
+Retrieves the identifiers for all the available aliases.
+
+## Example Usage
+
+```
+data "proxmox_virtual_environment_cluster_aliases" "available_aliases" {}
+```
+
+## Arguments Reference
+
+There are no arguments available for this data source.
+
+## Attributes Reference
+
+* `alias_ids` - The pool identifiers.

--- a/docs/resources/virtual_environment/proxmox_virtual_environment_alias.md
+++ b/docs/resources/virtual_environment/proxmox_virtual_environment_alias.md
@@ -1,0 +1,39 @@
+---
+layout: page
+title: Alias
+permalink: /ressources/virtual-environment/alias
+nav_order: 1
+parent: Virtual Environment Resources
+grand_parent: Resources
+---
+
+# Resource: Alias
+
+Aliases are used to see what devices or group of devices are affected by a rule.
+We can create aliases to identify an IP address or a network.
+
+## Example Usage
+
+```
+resource "proxmox_virtual_environment_cluster_alias" "local_network" {
+	name    = "local_network"
+	cidr    = "192.168.0.0/23"
+	comment = "Managed by Terraform"
+}
+
+resource "proxmox_virtual_environment_cluster_alias" "ubuntu_vm" {
+	name    = "ubuntu"
+	cidr    = "192.168.0.1"
+	comment = "Managed by Terraform"
+}
+```
+
+## Arguments Reference
+
+* `name` - (Required) Alias name.
+* `cidr` - (Required) Network/IP specification in CIDR format.
+* `comment` - (Optional) Alias comment.
+
+## Attributes Reference
+
+There are no attribute references available for this resource.

--- a/example/data_source_virtual_environment_cluster_alias.tf
+++ b/example/data_source_virtual_environment_cluster_alias.tf
@@ -1,0 +1,7 @@
+data "proxmox_virtual_environment_cluster_alias" "example" {
+  name = "example"
+}
+
+output "proxmox_virtual_environment_cluster_alias_example_cidr" {
+    value = proxmox_virtual_environment_cluster_alias.example.cidr
+}

--- a/example/data_source_virtual_environment_cluster_aliases.tf
+++ b/example/data_source_virtual_environment_cluster_aliases.tf
@@ -1,0 +1,9 @@
+data "proxmox_virtual_environment_cluster_aliases" "example" {
+    depends_on = ["proxmox_virtual_environment_cluster_alias.example"]
+}
+
+output "proxmox_virtual_environment_cluster_aliases" {
+  value = "${map(
+    "alias_ids", data.proxmox_virtual_environment_cluster_aliases.example.alias_ids,
+  )}"
+}

--- a/example/resource_virtual_environemnt_cluster_alias.tf
+++ b/example/resource_virtual_environemnt_cluster_alias.tf
@@ -1,0 +1,13 @@
+resource "proxmox_virtual_environment_cluster_alias" "example" {
+	name    = "local_network"
+	cidr    = "192.168.0.0/23"
+	comment = "Managed by Terraform"
+}
+
+output "proxmox_virtual_environment_cluster_alias_example_name" {
+  value = "${proxmox_virtual_environment_cluster_alias.example.name}"
+}
+
+output "proxmox_virtual_environment_cluster_alias_example_cidr" {
+  value = "${proxmox_virtual_environment_cluster_alias.example.cidr}"
+}

--- a/proxmox/virtual_environment_cluster_alias.go
+++ b/proxmox/virtual_environment_cluster_alias.go
@@ -1,0 +1,63 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+package proxmox
+
+import (
+	"errors"
+	"fmt"
+	"net/url"
+	"sort"
+)
+
+// CreateAlias create an alias
+func (c *VirtualEnvironmentClient) CreateAlias(d *VirtualEnvironmentClusterAliasCreateRequestBody) error  {
+	return c.DoRequest(hmPOST, "cluster/firewall/aliases", d, nil)
+}
+
+// DeleteAlias delete an alias
+func (c *VirtualEnvironmentClient) DeleteAlias(id string) error {
+	return c.DoRequest(hmDELETE, fmt.Sprintf("cluster/firewall/aliases/%s", url.PathEscape(id)), nil, nil)
+}
+
+// GetAlias retrieves an alias
+func (c *VirtualEnvironmentClient) GetAlias(id string) (*VirtualEnvironmentClusterAliasGetResponseData, error) {
+	resBody := &VirtualEnvironmentClusterAliasGetResponseBody{}
+	err := c.DoRequest(hmGET, fmt.Sprintf("cluster/firewall/aliases/%s", url.PathEscape(id)), nil, resBody)
+
+	if err != nil {
+		return nil, err
+	}
+
+	if resBody.Data == nil {
+		return nil, errors.New("The server did not include a data object in the response")
+	}
+
+	return resBody.Data, nil
+}
+
+// ListAlias retrieves a list of aliases.
+func (c *VirtualEnvironmentClient) ListAliases() ([]*VirtualEnvironmentClusterAliasGetResponseData, error) {
+	resBody := &VirtualEnvironmentClusterAliasListResponseBody{}
+	err := c.DoRequest(hmGET, "cluster/firewall/aliases", nil, resBody)
+
+	if err != nil {
+		return nil, err
+	}
+
+	if resBody.Data == nil {
+		return nil, errors.New("The server did not include a data object in the response")
+	}
+
+	sort.Slice(resBody.Data, func(i, j int) bool {
+		return resBody.Data[i].Name < resBody.Data[j].Name
+	})
+
+	return resBody.Data, nil
+}
+
+// UpdateAlias updates an alias.
+func (c *VirtualEnvironmentClient) UpdateAlias(id string, d *VirtualEnvironmentClusterAliasUpdateRequestBody) error {
+	return c.DoRequest(hmPUT, fmt.Sprintf("cluster/firewall/aliases/%s", url.PathEscape(id)), d, nil)
+}

--- a/proxmox/virtual_environment_cluster_alias_types.go
+++ b/proxmox/virtual_environment_cluster_alias_types.go
@@ -1,0 +1,39 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+package proxmox
+
+// VirtualEnvironmentClusterAliasCreateRequestBody contains the data for an alias create request.
+type VirtualEnvironmentClusterAliasCreateRequestBody struct {
+	Comment *string `json:"comment,omitempty" url:"comment,omitempty"`
+	Name    string  `json:"name" url:"name"`
+	CIDR    string  `json:"cidr" url:"cidr"`
+}
+
+// VirtualEnvironmentClusterAliasGetResponseBody contains the body from an alias get response.
+type VirtualEnvironmentClusterAliasGetResponseBody struct {
+	Data *VirtualEnvironmentClusterAliasGetResponseData `json:"data,omitempty"`
+}
+
+// VirtualEnvironmentClusterAliasGetResponseData contains the data from an alias get response.
+type VirtualEnvironmentClusterAliasGetResponseData struct {
+	Comment		*string `json:"comment,omitempty" url:"comment,omitempty"`
+	Name		string  `json:"name" url:"name"`
+	CIDR		string  `json:"cidr" url:"cidr"`
+	Digest  	*string `json:"digest" url:"digest"`
+	IPVersion	int		`json:"ipversion" url:"ipversion"`
+}
+
+// VirtualEnvironmentClusterAliasListResponseBody contains the data from an alias get response.
+type VirtualEnvironmentClusterAliasListResponseBody struct {
+	Data []*VirtualEnvironmentClusterAliasGetResponseData `json:"data,omitempty"`
+}
+
+// VirtualEnvironmentClusterAliasUpdateRequestBody contains the data for an alias update request.
+type VirtualEnvironmentClusterAliasUpdateRequestBody struct {
+	Comment *string `json:"comment,omitempty" url:"comment,omitempty"`
+	ReName	string  `json:"rename" url:"rename"`
+	CIDR	string  `json:"cidr" url:"cidr"`
+}
+

--- a/proxmoxtf/data_source_virtual_environment_alias.go
+++ b/proxmoxtf/data_source_virtual_environment_alias.go
@@ -1,0 +1,70 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+package proxmoxtf
+
+import (
+	"github.com/hashicorp/terraform/helper/schema"
+)
+
+const (
+	dvDataVirtualEnvironmentClusterAliasComment 	           = ""
+
+	mkDataSourceVirtualEnvironmentClusterAliasName             = "name"
+	mkDataSourceVirtualEnvironmentClusterAliasCIDR             = "cidr"
+	mkDataSourceVirtualEnvironmentClusterAliasComment          = "comment"
+
+)
+
+func dataSourceVirtualEnvironmentClusterAlias() *schema.Resource {
+	return &schema.Resource{
+		Schema: map[string]*schema.Schema{
+			mkDataSourceVirtualEnvironmentClusterAliasName: {
+				Type:        schema.TypeString,
+				Description: "Alias name",
+				Required:    true,
+			},
+			mkDataSourceVirtualEnvironmentClusterAliasCIDR: {
+				Type:        schema.TypeString,
+				Description: "IP/CIDR block",
+				Computed:    true,
+			},
+			mkDataSourceVirtualEnvironmentClusterAliasComment: {
+				Type:        schema.TypeString,
+				Description: "Alias comment",
+				Computed:    true,
+			},
+
+		},
+		Read: dataSourceVirtualEnvironmentAliasRead,
+	}
+}
+
+func dataSourceVirtualEnvironmentAliasRead(d *schema.ResourceData, m interface{}) error {
+	config := m.(providerConfiguration)
+	veClient, err := config.GetVEClient()
+
+	if err != nil {
+		return err
+	}
+
+	AliasID := d.Get(mkDataSourceVirtualEnvironmentClusterAliasName).(string)
+	Alias, err := veClient.GetAlias(AliasID)
+
+	if err != nil {
+		return err
+	}
+
+	d.SetId(AliasID)
+
+	d.Set(mkDataSourceVirtualEnvironmentClusterAliasCIDR, Alias.CIDR)
+
+	if Alias.Comment != nil {
+		d.Set(mkDataSourceVirtualEnvironmentClusterAliasComment, Alias.Comment)
+	} else {
+		d.Set(mkDataSourceVirtualEnvironmentClusterAliasComment, dvDataVirtualEnvironmentClusterAliasComment)
+	}
+
+	return nil
+}

--- a/proxmoxtf/data_source_virtual_environment_alias_test.go
+++ b/proxmoxtf/data_source_virtual_environment_alias_test.go
@@ -1,0 +1,40 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+package proxmoxtf
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform/helper/schema"
+)
+
+// TestDataSourceVirtualEnvironmentAliasInstantiation tests whether the DataSourceVirtualEnvironmentAlias instance can be instantiated.
+func TestDataSourceVirtualEnvironmentAliasInstantiation(t *testing.T) {
+	s := dataSourceVirtualEnvironmentClusterAlias()
+
+	if s == nil {
+		t.Fatalf("Cannot instantiate dataSourceVirtualEnvironmentAlias")
+	}
+}
+
+// TestDataSourceVirtualEnvironmentAliasSchema tests the dataSourceVirtualEnvironmentAlias schema.
+func TestDataSourceVirtualEnvironmentAliasSchema(t *testing.T) {
+	s := dataSourceVirtualEnvironmentClusterAlias()
+
+	testRequiredArguments(t, s, []string{
+		mkDataSourceVirtualEnvironmentClusterAliasName,
+	})
+
+	testComputedAttributes(t, s, []string{
+		mkDataSourceVirtualEnvironmentClusterAliasCIDR,
+		mkDataSourceVirtualEnvironmentClusterAliasComment,
+	})
+
+	testValueTypes(t, s, map[string]schema.ValueType{
+		mkDataSourceVirtualEnvironmentClusterAliasName: schema.TypeString,
+		mkDataSourceVirtualEnvironmentClusterAliasCIDR: schema.TypeString,
+		mkDataSourceVirtualEnvironmentClusterAliasComment: schema.TypeString,
+	})
+}

--- a/proxmoxtf/data_source_virtual_environment_aliases.go
+++ b/proxmoxtf/data_source_virtual_environment_aliases.go
@@ -1,0 +1,54 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+package proxmoxtf
+
+import (
+	"github.com/hashicorp/terraform/helper/schema"
+)
+
+const (
+	mkDataSourceVirtualEnvironmentClusterAliasesAliasIDs        = "alias_ids"
+)
+
+func dataSourceVirtualEnvironmentClusterAliases() *schema.Resource {
+	return &schema.Resource{
+		Schema: map[string]*schema.Schema{
+			mkDataSourceVirtualEnvironmentClusterAliasesAliasIDs: {
+				Type:        schema.TypeList,
+				Description: "Alias IDs",
+				Computed:    true,
+				Elem:        &schema.Schema{Type: schema.TypeString},
+			},
+		},
+		Read: dataSourceVirtualEnvironmentClusterAliasesRead,
+	}
+}
+
+func dataSourceVirtualEnvironmentClusterAliasesRead(d *schema.ResourceData, m interface{}) error {
+	config := m.(providerConfiguration)
+	veClient, err := config.GetVEClient()
+
+	if err != nil {
+		return err
+	}
+
+	list, err := veClient.ListPools()
+
+	if err != nil {
+		return err
+	}
+
+	aliasIDs := make([]interface{}, len(list))
+
+	for i, v := range list {
+		aliasIDs[i] = v.ID
+	}
+
+	d.SetId("aliases")
+
+	d.Set(mkDataSourceVirtualEnvironmentClusterAliasesAliasIDs, aliasIDs)
+
+	return nil
+}

--- a/proxmoxtf/data_source_virtual_environment_aliases_test.go
+++ b/proxmoxtf/data_source_virtual_environment_aliases_test.go
@@ -1,0 +1,33 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+package proxmoxtf
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform/helper/schema"
+)
+
+// TestDataSourceVirtualEnvironmentAliasesInstantiation tests whether the DataSourceVirtualEnvironmentAliases instance can be instantiated.
+func TestDataSourceVirtualEnvironmentAliasesInstantiation(t *testing.T) {
+	s := dataSourceVirtualEnvironmentClusterAliases()
+
+	if s == nil {
+		t.Fatalf("Cannot instantiate dataSourceVirtualEnvironmentAliases")
+	}
+}
+
+// TestDataSourceVirtualEnvironmentAliasesSchema tests the dataSourceVirtualEnvironmentAliases schema.
+func TestDataSourceVirtualEnvironmentAliasesSchema(t *testing.T) {
+	s := dataSourceVirtualEnvironmentClusterAliases()
+
+	testComputedAttributes(t, s, []string{
+		mkDataSourceVirtualEnvironmentClusterAliasesAliasIDs,
+	})
+
+	testValueTypes(t, s, map[string]schema.ValueType{
+		mkDataSourceVirtualEnvironmentClusterAliasesAliasIDs: schema.TypeList,
+	})
+}

--- a/proxmoxtf/provider.go
+++ b/proxmoxtf/provider.go
@@ -50,6 +50,8 @@ func Provider() *schema.Provider {
 			"proxmox_virtual_environment_user":       dataSourceVirtualEnvironmentUser(),
 			"proxmox_virtual_environment_users":      dataSourceVirtualEnvironmentUsers(),
 			"proxmox_virtual_environment_version":    dataSourceVirtualEnvironmentVersion(),
+			"proxmox_virtual_environment_cluster_alias":   dataSourceVirtualEnvironmentClusterAlias(),
+			"proxmox_virtual_environment_cluster_aliases": dataSourceVirtualEnvironmentClusterAliases(),
 		},
 		ResourcesMap: map[string]*schema.Resource{
 			"proxmox_virtual_environment_certificate": resourceVirtualEnvironmentCertificate(),
@@ -63,6 +65,7 @@ func Provider() *schema.Provider {
 			"proxmox_virtual_environment_time":        resourceVirtualEnvironmentTime(),
 			"proxmox_virtual_environment_user":        resourceVirtualEnvironmentUser(),
 			"proxmox_virtual_environment_vm":          resourceVirtualEnvironmentVM(),
+			"proxmox_virtual_environment_cluster_alias": resourceVirtualEnvironmentClusterAlias(),
 		},
 		Schema: map[string]*schema.Schema{
 			mkProviderVirtualEnvironment: {

--- a/proxmoxtf/resource_virtual_environment_cluster_alias.go
+++ b/proxmoxtf/resource_virtual_environment_cluster_alias.go
@@ -1,0 +1,184 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+package proxmoxtf
+
+import (
+	"github.com/danitso/terraform-provider-proxmox/proxmox"
+	"github.com/hashicorp/terraform/helper/schema"
+	"strings"
+)
+
+const (
+	dvResourceVirtualEnvironmentClusterAliasComment 	= ""
+
+	mkResourceVirtualEnvironmentClusterAliasName 		= "name"
+	mkResourceVirtualEnvironmentClusterAliasCIDR 		= "cidr"
+	mkResourceVirtualEnvironmentClusterAliasComment     = "comment"
+)
+
+func resourceVirtualEnvironmentClusterAlias() *schema.Resource {
+	return &schema.Resource{
+		Schema: map[string]*schema.Schema{
+			mkResourceVirtualEnvironmentClusterAliasName: {
+				Type: schema.TypeString,
+				Description: "Alias name",
+				Required: true,
+				ForceNew: false,
+			},
+			mkResourceVirtualEnvironmentClusterAliasCIDR: {
+				Type: schema.TypeString,
+				Description: "IP/CIDR block",
+				Required: true,
+				ForceNew: false,
+			},
+			mkResourceVirtualEnvironmentClusterAliasComment: {
+				Type: schema.TypeString,
+				Description: "Alias comment",
+				Optional: true,
+				Default: dvResourceVirtualEnvironmentClusterAliasComment,
+			},
+		},
+		Create: resourceVirtualEnvironmentClusterAliasCreate,
+		Read: resourceVirtualEnvironmentClusterAliasRead,
+		Update: resourceVirtualEnvironmentClusterAliasUpdate,
+		Delete: resourceVirtualEnvironmentClusterAliasDelete,
+	}
+}
+
+func resourceVirtualEnvironmentClusterAliasCreate(d *schema.ResourceData, m interface{}) error {
+	config := m.(providerConfiguration)
+	veClient, err := config.GetVEClient()
+
+	if err != nil {
+		return err
+	}
+
+	comment := d.Get(mkResourceVirtualEnvironmentClusterAliasComment).(string)
+	name := d.Get(mkResourceVirtualEnvironmentClusterAliasName).(string)
+	cidr := d.Get(mkResourceVirtualEnvironmentClusterAliasCIDR).(string)
+
+	body := &proxmox.VirtualEnvironmentClusterAliasCreateRequestBody{
+		Comment: &comment,
+		Name: name,
+		CIDR: cidr,
+	}
+
+	err = veClient.CreateAlias(body)
+
+	if err != nil {
+		return err
+	}
+
+	d.SetId(name)
+
+	return resourceVirtualEnvironmentClusterAliasRead(d, m)
+}
+
+func resourceVirtualEnvironmentClusterAliasRead(d *schema.ResourceData, m interface{}) error {
+	config := m.(providerConfiguration)
+	veClient, err := config.GetVEClient()
+
+	if err != nil {
+		return err
+	}
+
+	name := d.Id()
+	alias, err := veClient.GetAlias(name)
+
+	if err != nil {
+		if strings.Contains(err.Error(), "HTTP 404") {
+			d.SetId("")
+			return nil
+		}
+
+		return err
+	}
+
+	aliasMap := map[string]interface{}{
+		mkResourceVirtualEnvironmentClusterAliasComment: alias.Comment,
+		mkResourceVirtualEnvironmentClusterAliasName: alias.Name,
+		mkResourceVirtualEnvironmentClusterAliasCIDR: alias.CIDR,
+	}
+
+	for key, val := range aliasMap {
+		err = d.Set(key, val)
+
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func resourceVirtualEnvironmentClusterAliasUpdate(d *schema.ResourceData, m interface{}) error {
+	config := m.(providerConfiguration)
+	veClient, err := config.GetVEClient()
+
+	if err != nil {
+		return err
+	}
+
+	comment := d.Get(mkResourceVirtualEnvironmentClusterAliasComment).(string)
+	cidr := d.Get(mkResourceVirtualEnvironmentClusterAliasCIDR).(string)
+	newName := d.Get(mkResourceVirtualEnvironmentClusterAliasName).(string)
+	previousName := d.Id()
+
+	body := &proxmox.VirtualEnvironmentClusterAliasUpdateRequestBody{
+		ReName: newName,
+		CIDR: cidr,
+		Comment: &comment,
+	}
+
+	err = veClient.UpdateAlias(previousName, body)
+
+	if err != nil {
+		return err
+	}
+
+	d.SetId(newName)
+
+	return resourceVirtualEnvironmentClusterAliasRead(d, m)
+}
+
+
+func resourceVirtualEnvironmentClusterAliasDelete(d *schema.ResourceData, m interface{}) error {
+	config := m.(providerConfiguration)
+	veClient, err := config.GetVEClient()
+
+	if err != nil {
+		return nil
+	}
+
+	name := d.Id()
+	err = veClient.DeleteAlias(name)
+
+	if err != nil {
+		if strings.Contains(err.Error(), "HTTP 404") {
+			d.SetId("")
+			return nil
+		}
+
+		return err
+	}
+
+	d.SetId("")
+
+	return nil
+}
+
+
+
+
+
+
+
+
+
+
+
+
+
+

--- a/proxmoxtf/resource_virtual_environment_cluster_alias_test.go
+++ b/proxmoxtf/resource_virtual_environment_cluster_alias_test.go
@@ -1,0 +1,40 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+package proxmoxtf
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform/helper/schema"
+)
+
+// TestResourceVirtualEnvironmentAliasInstantiation tests whether the ResourceVirtualEnvironmentAlias instance can be instantiated.
+func TestResourceVirtualEnvironmentAliasInstantiation(t *testing.T) {
+	s := resourceVirtualEnvironmentClusterAlias()
+
+	if s == nil {
+		t.Fatalf("Cannot instantiate resourceVirtualEnvironmentAlias")
+	}
+}
+
+// TestResourceVirtualEnvironmentAliasSchema tests the resourceVirtualEnvironmentAlias schema.
+func TestResourceVirtualEnvironmentAliasSchema(t *testing.T) {
+	s := resourceVirtualEnvironmentClusterAlias()
+
+	testRequiredArguments(t, s, []string{
+		mkResourceVirtualEnvironmentClusterAliasName,
+		mkResourceVirtualEnvironmentClusterAliasCIDR,
+	})
+
+	testOptionalArguments(t, s, []string{
+		mkResourceVirtualEnvironmentClusterAliasComment,
+	})
+
+	testValueTypes(t, s, map[string]schema.ValueType{
+		mkResourceVirtualEnvironmentClusterAliasName: 	   schema.TypeString,
+		mkResourceVirtualEnvironmentClusterAliasCIDR:      schema.TypeString,
+		mkResourceVirtualEnvironmentClusterAliasComment:   schema.TypeString,
+	})
+}


### PR DESCRIPTION
<!--- Please keep this note for the community --->
### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request
<!--- Thank you for keeping this note for the community --->

This PR adds a cluster `alias` resource.

```release-note
Add `proxmox_virtual_environment_cluster_alias` resource
```
