### PR TITLE
Fix started diff when creating a template

### DIFF
--- a/proxmoxtf/resource_virtual_environment_vm.go
+++ b/proxmoxtf/resource_virtual_environment_vm.go
@@ -2915,7 +2915,9 @@ func resourceVirtualEnvironmentVMReadPrimitiveValues(d *schema.ResourceData, m i
 		}
 	}
 
-	d.Set(mkResourceVirtualEnvironmentVMStarted, vmStatus.Status == "running")
+	if d.Get(mkResourceVirtualEnvironmentVMTemplate).(bool) != true {
+		d.Set(mkResourceVirtualEnvironmentVMStarted, vmStatus.Status == "running")
+	}
 
 	currentTabletDevice := d.Get(mkResourceVirtualEnvironmentVMTabletDevice).(bool)
 


### PR DESCRIPTION
<!--- Please keep this note for the community --->
### Community Note

The `started` state was being set for templates, even though it doesn't make any sense. This patch simply omits setting the state value if the template flag is set.

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request
<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->

Didn't see an issue for this, but it's pretty easy to repro if you create a template and then try to re-apply.

Release note for [CHANGELOG](https://github.com/danitso/terraform-provider-proxmox/blob/master/CHANGELOG.md):
<!-- If change is not user facing, just write "NONE" in the release-note block below. -->

```release-note
BUG FIX: started no longer causes diff issues with templates
```
