### PR TITLE
Fix initialization state diff

### DIFF
--- a/proxmoxtf/resource_virtual_environment_vm.go
+++ b/proxmoxtf/resource_virtual_environment_vm.go
@@ -2519,7 +2519,9 @@ func resourceVirtualEnvironmentVMReadCustom(d *schema.ResourceData, m interface{
 		ipConfigList[ipConfigIndex] = ipConfigItem
 	}
 
-	initialization[mkResourceVirtualEnvironmentVMInitializationIPConfig] = ipConfigList[:ipConfigLast+1]
+	if ipConfigLast >= 0 {
+		initialization[mkResourceVirtualEnvironmentVMInitializationIPConfig] = ipConfigList[:ipConfigLast+1]
+	}
 
 	if vmConfig.CloudInitPassword != nil || vmConfig.CloudInitSSHKeys != nil || vmConfig.CloudInitUsername != nil {
 		initializationUserAccount := map[string]interface{}{}
@@ -2551,7 +2553,7 @@ func resourceVirtualEnvironmentVMReadCustom(d *schema.ResourceData, m interface{
 		} else {
 			initialization[mkResourceVirtualEnvironmentVMInitializationUserDataFileID] = ""
 		}
-	} else {
+	} else if len(initialization) > 0 {
 		initialization[mkResourceVirtualEnvironmentVMInitializationUserDataFileID] = ""
 	}
 


### PR DESCRIPTION
<!--- Please keep this note for the community --->
### Community Note

Adding some constraints to the `initialization` block
- ip configuration is now only added if there are any ip's defined
- default data file id is now only added if initialization is non-empty

I was running into this with a dynamic `initialization` block. When the block was not being created i would see an empty initialization diff being added on every apply.

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request
<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
relates to #30 (and possibly resolves it)

Release note for [CHANGELOG](https://github.com/danitso/terraform-provider-proxmox/blob/master/CHANGELOG.md):
<!-- If change is not user facing, just write "NONE" in the release-note block below. -->

```release-note
BUG FIX: initialization should no longer add an empty block on plan
```
