### PR TITLE
Fix `vm` resource: #41, #42

### DIFF
--- a/proxmoxtf/resource_virtual_environment_vm.go
+++ b/proxmoxtf/resource_virtual_environment_vm.go
@@ -1503,7 +1503,6 @@ func resourceVirtualEnvironmentVMCreateCustom(d *schema.ResourceData, m interfac
 		KeyboardLayout:      &keyboardLayout,
 		NetworkDevices:      networkDeviceObjects,
 		OSType:              &operatingSystemType,
-		PoolID:              &poolID,
 		SCSIDevices:         diskDeviceObjects,
 		SCSIHardware:        &scsiHardware,
 		SerialDevices:       serialDevices,
@@ -1530,6 +1529,10 @@ func resourceVirtualEnvironmentVMCreateCustom(d *schema.ResourceData, m interfac
 
 	if name != "" {
 		createBody.Name = &name
+	}
+
+	if poolID != "" {
+		createBody.PoolID = &poolID
 	}
 
 	err = veClient.CreateVM(nodeName, createBody)
@@ -3011,7 +3014,12 @@ func resourceVirtualEnvironmentVMUpdate(d *schema.ResourceData, m interface{}) e
 	}
 
 	name := d.Get(mkResourceVirtualEnvironmentVMName).(string)
-	updateBody.Name = &name
+
+	if name == "" {
+		delete = append(delete, "name")
+	} else {
+		updateBody.Name = &name
+	}
 
 	if d.HasChange(mkResourceVirtualEnvironmentVMTabletDevice) {
 		tabletDevice := proxmox.CustomBool(d.Get(mkResourceVirtualEnvironmentVMTabletDevice).(bool))


### PR DESCRIPTION
<!--- Please keep this note for the community --->
### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request
<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #41 
Closes #42 

Release note for [CHANGELOG](https://github.com/danitso/terraform-provider-proxmox/blob/master/CHANGELOG.md):
<!-- If change is not user facing, just write "NONE" in the release-note block below. -->

```release-note
BUG FIX: Creating a VM resource always fails if `pool_id` (an argument marked optional) is not supplied
BUG FIX: Modifying a VM resource always fails if `name` (an argument marked optional) is omitted or does not look like a "DNS name"
```
