### PR TITLE
Fix a typo and make disk import coherent with disk interface

### DIFF
--- a/proxmoxtf/resource_virtual_environment_vm.go
+++ b/proxmoxtf/resource_virtual_environment_vm.go
@@ -1549,7 +1549,7 @@ func resourceVirtualEnvironmentVMCreateCustom(d *schema.ResourceData, m interfac
 		return err
 	}
 
-	virtioDeviceObjects := diskDeviceObjects["vitio"]
+	virtioDeviceObjects := diskDeviceObjects["virtio"]
 	scsiDeviceObjects := diskDeviceObjects["scsi"]
 	//ideDeviceObjects := getOrderedDiskDeviceList(diskDeviceObjects, "ide")
 	sataDeviceObjects := diskDeviceObjects["sata"]
@@ -1798,6 +1798,7 @@ func resourceVirtualEnvironmentVMCreateCustomDisks(d *schema.ResourceData, m int
 		fileFormat, _ := block[mkResourceVirtualEnvironmentVMDiskFileFormat].(string)
 		size, _ := block[mkResourceVirtualEnvironmentVMDiskSize].(int)
 		speed := block[mkResourceVirtualEnvironmentVMDiskSpeed].([]interface{})
+		diskInterface,_ := block[mkResourcevirtualEnvironmentVMDiskInterface].(string)
 
 		if len(speed) == 0 {
 			diskSpeedDefault, err := diskSpeedResource.DefaultValue()
@@ -1853,6 +1854,7 @@ func resourceVirtualEnvironmentVMCreateCustomDisks(d *schema.ResourceData, m int
 			fmt.Sprintf(`disk_index="%d"`, i),
 			fmt.Sprintf(`disk_options="%s"`, diskOptions),
 			fmt.Sprintf(`disk_size="%d"`, size),
+			fmt.Sprintf(`disk_interface="%s"`, diskInterface),
 			fmt.Sprintf(`file_path="%s"`, filePath),
 			fmt.Sprintf(`file_path_tmp="%s"`, filePathTmp),
 			fmt.Sprintf(`vm_id="%d"`, vmID),
@@ -1867,7 +1869,7 @@ func resourceVirtualEnvironmentVMCreateCustomDisks(d *schema.ResourceData, m int
 			`qemu-img resize "$file_path_tmp" "${disk_size}G"`,
 			`qm importdisk "$vm_id" "$file_path_tmp" "$datastore_id_target" -format qcow2`,
 			`disk_id="${datastore_id_target}:$([[ -n "$dsp_target" ]] && echo "${vm_id}/" || echo "")vm-${vm_id}-disk-${disk_count}$([[ -n "$dsp_target" ]] && echo ".qcow2" || echo "")${disk_options}"`,
-			`qm set "$vm_id" "-scsi${disk_index}" "$disk_id"`,
+			`qm set "$vm_id" "-${disk_interface}" "$disk_id"`,
 			`rm -f "$file_path_tmp"`,
 		)
 


### PR DESCRIPTION
Fix a small typo in resourceVirtualEnvironmentVMCreateCustom function and make the provider capable to import disk with the correct interface

<!--- Please keep this note for the community --->
### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request
<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #67

Release note for [CHANGELOG](https://github.com/danitso/terraform-provider-proxmox/blob/master/CHANGELOG.md):
<!-- If change is not user facing, just write "NONE" in the release-note block below. -->

```release-note
fix a typo and make resourceVirtualEnvironmentVMCreateCustomDisks capable of importing disk with the correct interface
```
