### PR TITLE
Fix JSON parse error on PID and VMID

### DIFF
--- a/proxmox/virtual_environment_vm_types.go
+++ b/proxmox/virtual_environment_vm_types.go
@@ -478,14 +478,14 @@ type VirtualEnvironmentVMGetStatusResponseData struct {
 	Lock             *string     `json:"lock,omitempty"`
 	MemoryAllocation *int        `json:"maxmem,omitempty"`
 	Name             *string     `json:"name,omitempty"`
-	PID              *string     `json:"pid,omitempty"`
+	PID              *int        `json:"pid,omitempty"`
 	QMPStatus        *string     `json:"qmpstatus,omitempty"`
 	RootDiskSize     *int        `json:"maxdisk,omitempty"`
 	SpiceSupport     *CustomBool `json:"spice,omitempty"`
 	Status           string      `json:"status,omitempty"`
 	Tags             *string     `json:"tags,omitempty"`
 	Uptime           *int        `json:"uptime,omitempty"`
-	VMID             string      `json:"vmid,omitempty"`
+	VMID             int         `json:"vmid,omitempty"`
 }
 
 // VirtualEnvironmentVMListResponseBody contains the body from an virtual machine list response.


### PR DESCRIPTION
<!--- Please keep this note for the community --->
### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request
<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Closes #98
Related to #99 but fixes another ID also

Release note for [CHANGELOG](https://github.com/danitso/terraform-provider-proxmox/blob/master/CHANGELOG.md):
<!-- If change is not user facing, just write "NONE" in the release-note block below. -->

```release-note
Fix bug in parsing VMID and PID
```
